### PR TITLE
logic so user cannot add recipe to fav and weekly again

### DIFF
--- a/src/components/BasketButton.jsx
+++ b/src/components/BasketButton.jsx
@@ -9,9 +9,11 @@ import AddWeekly from "./WeeklyServer";
 export default function BasketButton({ recipe_id }) {
   const [btnClass, setBtnClass] = useState(false);
   const [btnColor, setBtnColor] = useState("white");
+  const [isClicked, setIsClicked] = useState(false);
 
   const handleWeeklyShop = async () => {
     setBtnColor(btnColor === "white" ? "green" : "white");
+    setIsClicked(true);
 
     await AddWeekly(recipe_id);
   };
@@ -21,8 +23,8 @@ export default function BasketButton({ recipe_id }) {
       <button
         type="submit"
         className="btn"
-        //   formAction={addfavourite}
         onClick={handleWeeklyShop}
+        disabled={isClicked}
         style={{ backgroundColor: btnColor }}
       >
         <GrBasket size={24} />

--- a/src/components/FavouriteClient.jsx
+++ b/src/components/FavouriteClient.jsx
@@ -9,9 +9,11 @@ import AddFavourite from "./FavouriteServer";
 export default function FavouriteButton({ recipe_id }) {
   // const [btnClass, setBtnClass] = useState(false);
   const [btnColor, setBtnColor] = useState("white");
+  const [isClicked, setIsClicked] = useState(false);
 
   const handleFavouriteSubmit = async () => {
     setBtnColor(btnColor === "white" ? "red" : "white");
+    setIsClicked(true);
 
     await AddFavourite(recipe_id);
   };
@@ -21,6 +23,7 @@ export default function FavouriteButton({ recipe_id }) {
         type="submit"
         className="btn"
         onClick={handleFavouriteSubmit}
+        disabled={isClicked}
         style={{ backgroundColor: btnColor }}
       >
         <svg

--- a/src/components/FavouriteServer.jsx
+++ b/src/components/FavouriteServer.jsx
@@ -7,9 +7,22 @@ export default async function AddFavourite(recipe_id) {
   const { userId } = await auth();
   console.log(recipe_id);
 
+  const existingFavourite = await db.query(
+    `SELECT * FROM favourites WHERE user_clerk_id = $1 AND recipe_id = $2`,
+    [userId, recipe_id]
+  );
+
+  if (existingFavourite.rowCount > 0) {
+    console.log("This recipe is already in the user's favourite.");
+    return { message: "Already in favourites" };
+  }
+
   await db.query(
     `INSERT INTO favourites (user_clerk_id, recipe_id)
     VALUES ($1, $2)`,
     [userId, recipe_id]
   );
+
+  console.log("recipe added to favourites");
+  return { message: "Added to favourites" };
 }

--- a/src/components/WeeklyServer.jsx
+++ b/src/components/WeeklyServer.jsx
@@ -11,11 +11,24 @@ export default async function AddWeekly(recipe_id) {
   //   this is where we are determining the users current session
   const session_id = await getCurrentSessionId();
 
+  const existingWeekly = await db.query(
+    `SELECT * FROM weekly WHERE user_clerk_id = $1 AND recipe_id = $2 AND session_id = $3`,
+    [userId, recipe_id, session_id]
+  );
+
+  if (existingWeekly.rowCount > 0) {
+    console.log("This recipe is already in the user's weekly.");
+    return { message: "Already in weekly" };
+  }
+
   await db.query(
     `INSERT INTO weekly (recipe_id, user_clerk_id, session_id)
     VALUES ($1, $2, $3)`,
     [recipe_id, userId, session_id]
   );
+
+  console.log("recipe added to favourites");
+  return { message: "Added to favourites" };
 }
 
 export async function RemoveWeekly(recipe_id) {


### PR DESCRIPTION
button stays clicked in on recipes page - but on refresh will appear unclicked again - need to use local storage maybe ? 
No longer get error that recipe has been fav or added to weekly with logic in queries added 